### PR TITLE
Fix: Prevent fatal errors by replacing `exit()` with `error_log()` in SMTP2GO class autoloader

### DIFF
--- a/smtp2go-class-loader.php
+++ b/smtp2go-class-loader.php
@@ -21,7 +21,7 @@ function SMTP2GOClassLoader($className)
     if (file_exists($fullFileName)) {
         require_once $fullFileName;
     } else {
-        exit('FAIL! Namespace: ' .$namespace .' Class "' . $className . '" wasn\'t found in ' . $includePath . ' as ' . $fileName);
+        error_log('SMTP2GO Class Loader Error - Namespace: ' . $namespace . ' Class "' . $className . '" wasn\'t found in ' . $includePath . ' as ' . $fileName);
     }
 }
 spl_autoload_register('SMTP2GOClassLoader');


### PR DESCRIPTION
### 🔧 Change Summary

This update replaces a direct call to `exit()` with `error_log()` in the `SMTP2GOClassLoader` function. The change prevents the abrupt termination of script execution when a class is not found, and instead logs the issue for debugging purposes.

We are raising this PR because the use of `exit()` is causing the whole WordPress site to crash if the SureMail plugin is installed and a class is missing. Replacing it with `error_log()` helps avoid a full site crash and makes it easier to debug the issue.

### 📂 Affected File

`smtp2go/smtp2go-class-loader.php`

### 🛠️ Original Code

```php
else {
    exit('FAIL! Namespace: ' .$namespace .' Class "' . $className . '" wasn\'t found in ' . $includePath . ' as ' . $fileName);
}
```

### 🛠️ ✅ Updated Code

```php
else {
    error_log('SMTP2GO Class Loader Error - Namespace: ' . $namespace . ' Class "' . $className . '" wasn\'t found in ' . $includePath . ' as ' . $fileName);
}
