### PR TITLE
Add API region support (us / eu / au)

### DIFF
--- a/app/SMTP2GOMailer.php
+++ b/app/SMTP2GOMailer.php
@@ -93,7 +93,10 @@ class SMTP2GOMailer extends PHPMailer
         $apiKey = SettingsHelper::getOption('smtp2go_api_key');
 
         $keyHelper = new SecureApiKeyHelper();
-        $client = $this->apiClient ?? new ApiClient($keyHelper->decryptKey($apiKey));
+        // makeApiClient() applies the configured API region (and the
+        // `smtp2go_api_region` filter) to the new client. If a client has
+        // already been injected via setApiClient() we leave it alone.
+        $client = $this->apiClient ?? SettingsHelper::makeApiClient($keyHelper->decryptKey($apiKey));
         $client->setMaxSendAttempts(2);
         $client->setTimeoutIncrement(0);
 

--- a/app/SettingsHelper.php
+++ b/app/SettingsHelper.php
@@ -2,12 +2,21 @@
 
 namespace SMTP2GO\App;
 
+use SMTP2GOWPPlugin\SMTP2GO\ApiClient;
+
 class SettingsHelper
 {
 
     private static $fieldToConstantMapping = array(
-        'smtp2go_api_key' => 'SMTP2GO_API_KEY',
+        'smtp2go_api_key'    => 'SMTP2GO_API_KEY',
+        'smtp2go_api_region' => 'SMTP2GO_API_REGION',
     );
+
+    /**
+     * Allowed values for the smtp2go_api_region option.
+     * Empty string means "use the default global endpoint".
+     */
+    const ALLOWED_API_REGIONS = ['', 'us', 'eu', 'au'];
 
     public static function settingHasDefinedConstant($field)
     {
@@ -28,5 +37,40 @@ class SettingsHelper
             return constant(static::$fieldToConstantMapping[$field]);
         }
         return get_option($field);
+    }
+
+    /**
+     * Resolve the API region to use for outbound requests.
+     *
+     * Reads the smtp2go_api_region option and runs it through the
+     * `smtp2go_api_region` filter so developers can override per-environment
+     * (e.g. staging vs production) without touching the database.
+     *
+     * @return string One of '', 'us', 'eu', 'au'. Empty string = global endpoint.
+     */
+    public static function getApiRegion(): string
+    {
+        $region = (string) static::getOption('smtp2go_api_region');
+        $region = (string) apply_filters('smtp2go_api_region', $region);
+
+        return in_array($region, static::ALLOWED_API_REGIONS, true) ? $region : '';
+    }
+
+    /**
+     * Build an ApiClient with the configured region applied.
+     *
+     * Centralised here so every call site (mailer, stats, permissions check)
+     * picks up the region setting consistently.
+     *
+     * @param string $decryptedApiKey The already-decrypted SMTP2GO API key.
+     */
+    public static function makeApiClient(string $decryptedApiKey): ApiClient
+    {
+        $client = new ApiClient($decryptedApiKey);
+        $region = static::getApiRegion();
+        if ($region !== '') {
+            $client->setApiRegion($region);
+        }
+        return $client;
     }
 }

--- a/app/WordpressPluginAdmin.php
+++ b/app/WordpressPluginAdmin.php
@@ -3,7 +3,6 @@
 namespace SMTP2GO\App;
 
 
-use SMTP2GOWPPlugin\SMTP2GO\ApiClient;
 use SMTP2GOWPPlugin\SMTP2GO\Service\Service;
 
 require_once dirname(__FILE__, 2) . '/build/vendor/autoload.php';
@@ -145,7 +144,7 @@ class WordpressPluginAdmin
             return;
         }
         $apiKey    = $this->keyHelper->decryptKey($apiKey);
-        $client = new ApiClient($apiKey);
+        $client = SettingsHelper::makeApiClient($apiKey);
         $stats   = null;
         if ($client->consume(new Service('stats/email_cycle'))) {
             $body = $client->getResponseBody();
@@ -282,6 +281,28 @@ class WordpressPluginAdmin
             'smtp2go_api_key',
             __('API Key *', $this->plugin_name),
             array($this, 'outputApiKeyHtml'),
+            $this->plugin_name,
+            'smtp2go_settings_section',
+            array()
+        );
+
+        /** api region field */
+        if (!SettingsHelper::settingHasDefinedConstant('smtp2go_api_region')) {
+            register_setting(
+                'api_settings',
+                'smtp2go_api_region',
+                array(
+                    'type'              => 'string',
+                    'sanitize_callback' => array($this, 'validateApiRegion'),
+                    'default'           => '',
+                )
+            );
+        }
+
+        add_settings_field(
+            'smtp2go_api_region',
+            __('API Region', $this->plugin_name),
+            array($this, 'outputRegionDropdownHtml'),
             $this->plugin_name,
             'smtp2go_settings_section',
             array()
@@ -546,6 +567,39 @@ class WordpressPluginAdmin
         echo $hint;
     }
 
+    /**
+     * Render the API region dropdown.
+     *
+     * Default ('') keeps the historical behaviour (global api.smtp2go.com
+     * endpoint). The other options pin requests to a specific regional
+     * endpoint via ApiClient::setApiRegion().
+     */
+    public function outputRegionDropdownHtml()
+    {
+        $field_name = 'smtp2go_api_region';
+        $current    = (string) SettingsHelper::getOption($field_name);
+        $options    = array(
+            ''   => __('Default (api.smtp2go.com)', $this->plugin_name),
+            'us' => __('United States (us-api.smtp2go.com)', $this->plugin_name),
+            'eu' => __('Europe (eu-api.smtp2go.com)', $this->plugin_name),
+            'au' => __('Australia (au-api.smtp2go.com)', $this->plugin_name),
+        );
+
+        echo '<select id="' . esc_attr($field_name) . '" name="' . esc_attr($field_name) . '" class="smtp2go_text_input">';
+        foreach ($options as $value => $label) {
+            printf(
+                '<option value="%s"%s>%s</option>',
+                esc_attr($value),
+                selected($current, $value, false),
+                esc_html($label)
+            );
+        }
+        echo '</select>';
+        echo '<br /><label for="' . esc_attr($field_name) . '"><span style="cursor: default; font-weight: normal;">'
+            . esc_html__('Pin API requests to a specific regional endpoint. Leave on Default unless you have a data residency requirement.', $this->plugin_name)
+            . '</span></label>';
+    }
+
     public function outputApiKeyHtml()
     {
         if (SettingsHelper::settingHasDefinedConstant('smtp2go_api_key')) {
@@ -609,7 +663,7 @@ class WordpressPluginAdmin
         $apiKey = SettingsHelper::getOption('smtp2go_api_key');
         $apiKeyHelper = new SecureApiKeyHelper();
         $decryptedKey = $apiKeyHelper->decryptKey($apiKey);
-        $client = new ApiClient($decryptedKey);
+        $client = SettingsHelper::makeApiClient($decryptedKey);
         $stats   = null;
 
         if ($this->hasEndpointPermission('/stats/email_summary') && $client->consume(new Service('stats/email_summary', ['username' => substr($decryptedKey, 0, 16)]))) {
@@ -734,7 +788,7 @@ class WordpressPluginAdmin
         }
         $apiKey = $this->keyHelper->decryptKey($apiKey);
 
-        $client = new ApiClient($apiKey);
+        $client = SettingsHelper::makeApiClient($apiKey);
 
         // what is this for?
         if (empty($apiKey)) {
@@ -816,6 +870,19 @@ class WordpressPluginAdmin
         }
 
         return sanitize_text_field($input);
+    }
+
+    /**
+     * Reject any region value that isn't one the SMTP2GO SDK supports.
+     * Falls back to empty string (= default global endpoint) on bad input.
+     */
+    public function validateApiRegion($input)
+    {
+        if (in_array($input, SettingsHelper::ALLOWED_API_REGIONS, true)) {
+            return $input;
+        }
+        add_settings_error('smtp2go_messages', 'smtp2go_message', __('Invalid API Region selected.', $this->plugin_name));
+        return '';
     }
 
     public function addSettingsLink($links)

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: email, smtp, inbox, delivery, wp_mail
 Requires at least: 6.2
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.15.0
+Stable tag: 1.16.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -138,6 +138,10 @@ Our data centers are located around the world, meaning lightning-fast connection
 
 == Changelog ==
 
+= v1.16.0 =
+* add "API Region" setting to pin requests to a specific regional endpoint (US, EU, AU)
+* add `smtp2go_api_region` filter for programmatic per-environment overrides
+* add `SMTP2GO_API_REGION` constant support (when `SMTP2GO_USE_CONSTANTS` is true)
 = v1.15.0 =
 * security updates
 = v1.14.1 =

--- a/smtp2go-wordpress-plugin.php
+++ b/smtp2go-wordpress-plugin.php
@@ -15,7 +15,7 @@
  * Plugin Name:       SMTP2GO - Email Made Easy
  * Plugin URI:        https://github.com/thefold/smtp2go-wordpress-plugin
  * Description:       Send all email from WordPress via SMTP2GO. Scalable, reliable email delivery. https://www.smtp2go.com/.
- * Version:           1.15.0
+ * Version:           1.16.0
  * Author:            SMTP2GO
  * Author URI:        https://www.smtp2go.com
  * License:           GPL-2.0+
@@ -37,7 +37,7 @@ if (!defined('WPINC')) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define('SMTP2GO_WORDPRESS_PLUGIN_VERSION', '1.15.0');
+define('SMTP2GO_WORDPRESS_PLUGIN_VERSION', '1.16.0');
 
 define('SMTP2GO_PLUGIN_BASENAME', plugin_basename(__FILE__));
 /**


### PR DESCRIPTION
## Summary

Adds the ability to pin SMTP2GO API requests to a specific regional endpoint
(`us-api`, `eu-api`, `au-api`) instead of always hitting the global
`api.smtp2go.com`. Useful for sites with data-residency requirements or
where the global routing isn't optimal for their location.

When no region is configured the plugin behaves exactly as before — requests
go to the global endpoint.

## Changes

- New **API Region** setting on the plugin's settings screen with options:
Global (default), US, EU, AU.
- New `smtp2go_api_region` filter so the region can be overridden
per-environment (e.g. staging vs. production) without touching the database.
- Region resolution centralised in `SettingsHelper::makeApiClient()` so the
mailer, stats lookups, and API key permission checks all use the same
region consistently.
- The underlying `ApiClient::setApiRegion()` was already present in the
vendored `smtp2go-oss/smtp2go-php` SDK — this PR just exposes it through
the WordPress plugin.

**Screenshot of new field:**
<img width="1432" height="124" alt="image" src="https://github.com/user-attachments/assets/86c7f304-14d5-472c-a758-00338d5ac8fb" />

## Files touched

- `app/SettingsHelper.php` — `getApiRegion()`, `makeApiClient()`, allowed
region constant.
- `app/SMTP2GOMailer.php` — uses `makeApiClient()` so sends honour the region.
- `app/WordpressPluginAdmin.php` — adds the settings field and saves the
option with validation against the allowed list.
- `readme.txt` — documents the new setting.
- `smtp2go-wordpress-plugin.php` — version bump.

## Testing

- Tested on a live WordPress install.
- Verified via `WP_DEBUG` log that with region set to `au`, the
`ApiClient` instance used to send the email has `apiRegion => au` and
the request returns `200 OK` from SMTP2GO with `succeeded => 1`.
- Verified that with region left as Global, behaviour is unchanged
(still hits `api.smtp2go.com`).
- Verified the `smtp2go_api_region` filter overrides the stored option.

## Unable to test with standard SMTP2GO access

- Someone who can actually confirm that it IS hitting the right servers should test this. All I can check is what I can 'report on' in WordPress - and this will only tell me the endpoint I'm allegedly hitting, not what is actually being hit. I'm sure you have additional logging and reporting in place that will allow you to test this in all regions.